### PR TITLE
More changes to Hermit

### DIFF
--- a/src/main/java/charbosses/bosses/Hermit/NewAge/ArchetypeAct2WheelOfFateNewAge.java
+++ b/src/main/java/charbosses/bosses/Hermit/NewAge/ArchetypeAct2WheelOfFateNewAge.java
@@ -114,12 +114,10 @@ public class ArchetypeAct2WheelOfFateNewAge extends ArchetypeBaseIronclad {
         for (int i = 0; i < 3; i++) {
             AbstractCard target = getNextCard();
             cardsList.add(target);
-            // No strength gain for now.
-            /*
+
             if (target.cardID.equals(EnNecronomicurse.ID)) {
                 AbstractCharBoss.boss.getPower(HermitWheelOfFortune.POWER_ID).onSpecificTrigger();
             }
-             */
         }
         if (AbstractCharBoss.boss instanceof CharBossHermit) {
             CharBossHermit.previewCard = mockDeck.get(0).makeStatEquivalentCopy();
@@ -153,12 +151,11 @@ public class ArchetypeAct2WheelOfFateNewAge extends ArchetypeBaseIronclad {
         }
         AbstractCard next = getNextCard();
         AbstractCharBoss.boss.hand.addToTop(next);
-        // Not here either.
-        /*
+
         if (next.cardID.equals(EnNecronomicurse.ID)) {
             AbstractCharBoss.boss.getPower(HermitWheelOfFortune.POWER_ID).onSpecificTrigger();
         }
-         */
+
         AbstractCharBoss.boss.hand.refreshHandLayout();
         AbstractDungeon.actionManager.addToTop(new AbstractGameAction() {
             @Override

--- a/src/main/java/hermit/actions/LoneWolfAction.java
+++ b/src/main/java/hermit/actions/LoneWolfAction.java
@@ -42,7 +42,7 @@ public class LoneWolfAction extends AbstractGameAction {
                 for(int n = 0; n < i; ++n) {
                     c = p.hand.getTopCard();
                     if (c.cost > 0) {
-                        c.freeToPlayOnce = true;
+                        c.setCostForTurn(0);
                         c.superFlash(Color.GOLD.cpy());
                     }
                 }
@@ -70,7 +70,7 @@ public class LoneWolfAction extends AbstractGameAction {
                 p.hand.removeCard(c);
 
                 if (c.cost > 0) {
-                    c.freeToPlayOnce = true;
+                    c.setCostForTurn(0);
                     c.superFlash(Color.GOLD.cpy());
                 }
 

--- a/src/main/java/hermit/actions/ReduceDebuffsAction.java
+++ b/src/main/java/hermit/actions/ReduceDebuffsAction.java
@@ -4,9 +4,9 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.powers.AbstractPower.PowerType;
-import java.util.Iterator;
 
 public class ReduceDebuffsAction extends AbstractGameAction {
     private AbstractCreature c;
@@ -17,13 +17,35 @@ public class ReduceDebuffsAction extends AbstractGameAction {
         this.amount=amount;
     }
 
+    // Jacked from Packmaster.
     public void update() {
-        Iterator var1 = this.c.powers.iterator();
+        if (this.amount <= 0) {
+            this.isDone = true;
+            return;
+        }
 
-        while(var1.hasNext()) {
-            AbstractPower p = (AbstractPower)var1.next();
+        for (AbstractPower p : this.c.powers) {
             if (p.type == PowerType.DEBUFF) {
-                this.addToTop(new ReducePowerAction(this.c, this.c, p.ID, amount));
+                // ReducePowerAction only works properly for powers with positive amount, so we use our own action to
+                // handle the various debuffs that have negative amount (e.g. Wraith Form, negative Dexterity). This also
+                // handles debuffs that don't stack (e.g. NoDrawPower from Battle Trance), since those use amount -1.
+                if (p.amount > 0) {
+                    this.addToTop(new ReducePowerAction(this.c, this.c, p.ID, this.amount));
+                }
+                else if (p.amount < 0 && Math.abs(p.amount) <= this.amount) {
+                    this.addToTop(new RemoveSpecificPowerAction(this.c, this.c, p));
+                }
+                else {
+                    this.addToTop(new AbstractGameAction() {
+                        @Override
+                        public void update() {
+                            p.stackPower(ReduceDebuffsAction.this.amount);
+                            p.updateDescription();
+                            AbstractDungeon.onModifyPower();
+                            this.isDone = true;
+                        }
+                    });
+                }
             }
         }
 

--- a/src/main/java/hermit/cards/Dissolve.java
+++ b/src/main/java/hermit/cards/Dissolve.java
@@ -36,13 +36,15 @@ public class Dissolve extends AbstractDynamicCard {
     public static final CardColor COLOR = hermit.Enums.COLOR_YELLOW;
 
     private static final int COST = 2;
+    private static final int BLOCK = 18;
+    private static final int UPGRADE_PLUS_BLOCK = 7;
 
     // /STAT DECLARATION/
 
     public Dissolve() {
         super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = 2;
-        baseBlock = block = 12;
+        baseBlock = block = BLOCK;
         this.exhaust=true;
         loadJokeCardImage(this, "dissolve.png");
     }
@@ -59,7 +61,7 @@ public class Dissolve extends AbstractDynamicCard {
     public void upgrade() {
         if (!upgraded) {
             upgradeName();
-            upgradeBlock(6);
+            upgradeBlock(UPGRADE_PLUS_BLOCK);
             initializeDescription();
         }
     }

--- a/src/main/java/hermit/cards/FinalCanter.java
+++ b/src/main/java/hermit/cards/FinalCanter.java
@@ -53,13 +53,8 @@ public class FinalCanter extends AbstractDynamicCard {
     public void use(AbstractPlayer p, AbstractMonster m) {
         magicNumber = countCards();
 
-        for (AbstractCard c: AbstractDungeon.player.hand.group)
-            if (c.color==CardColor.CURSE)
-                Wiz.atb(new ExhaustSpecificCardAction(c,Wiz.p().hand));
-
         for (int ii=0; ii < magicNumber; ii++)
             Wiz.atb(new FinalCanterAction(m,p,this.damage,this));
-
 
         this.rawDescription = cardStrings.DESCRIPTION;
         this.initializeDescription();

--- a/src/main/java/hermit/cards/Virtue.java
+++ b/src/main/java/hermit/cards/Virtue.java
@@ -12,6 +12,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.vfx.combat.HealVerticalLineEffect;
 import hermit.HermitMod;
+import hermit.actions.ReduceDebuffsAction;
 import hermit.characters.hermit;
 import hermit.util.Wiz;
 
@@ -72,15 +73,7 @@ public class Virtue extends AbstractDynamicCard {
             AbstractDungeon.effectsQueue.add(new HealVerticalLineEffect((p.hb.cX - p.animX) + MathUtils.random(-X_JITTER * 1.5F, X_JITTER * 1.5F),  p.hb.cY + OFFSET_Y + MathUtils.random(-Y_JITTER, Y_JITTER)));
         }
 
-        Wiz.atb(new AbstractGameAction() {
-            @Override
-            public void update() {
-                Wiz.p().powers.stream()
-                        .filter(p -> p.type == AbstractPower.PowerType.DEBUFF)
-                        .forEach(p -> Wiz.att(new ReducePowerAction(p.owner, p.owner, p.ID, Virtue.this.magicNumber)));
-                isDone = true;
-            }
-        });
+        Wiz.atb(new ReduceDebuffsAction(p, magicNumber));
     }
 
     //Upgraded stats.

--- a/src/main/java/hermit/powers/Rugged.java
+++ b/src/main/java/hermit/powers/Rugged.java
@@ -34,6 +34,8 @@ public class Rugged extends AbstractPower implements CloneablePowerInterface {
         this.owner = owner;
         this.amount = amount;
 
+        priority = 6;
+
         type = PowerType.BUFF;
 
         if (this.amount <= 0) {

--- a/src/main/resources/downfallResources/localization/eng/PowerStrings.json
+++ b/src/main/resources/downfallResources/localization/eng/PowerStrings.json
@@ -334,7 +334,7 @@
   "downfall:HermitWheelOfFortune": {
     "NAME": "Wheel of Fortune",
     "DESCRIPTIONS": [
-      "Hermit's card cost can't change. Whenever you play an #yAttack, Hermit discards his leftmost card and draws #b1 card."
+      "After you play an #yAttack, Hermit #yCycles his first card. Whenever he draws #yNecronomicurse, he gains #b2 #yStrength. Hermit's card cost can't change."
     ]
   },
   "downfall:HermitDoomsday": {

--- a/src/main/resources/hermitResources/localization/eng/CardStrings.json
+++ b/src/main/resources/hermitResources/localization/eng/CardStrings.json
@@ -309,7 +309,7 @@
   },
   "hermit:FinalCanter": {
     "NAME": "Final Canter",
-    "DESCRIPTION": "Retain. NL Exhaust all Curses in hand. Deal !D! damage for each. Exhaust.",
+    "DESCRIPTION": "Retain. NL Deal !D! damage for each Curse in hand. NL Exhaust.",
     "UPGRADE_DESCRIPTION": " NL (You have !M! Curse.)",
     "EXTENDED_DESCRIPTION": [" NL (You have !M! Curses.)"]
   },


### PR DESCRIPTION
- Act 2 Hermit boss power reworded, gains Strength when drawing Necronomicurse again.
- Dissolve gains more Block.
- Final Canter no longer exhausts Curses. (That's Spite's job now.)
- Lone Wolf cost reduction no longer carries over turns if the card remains in your hand.
- Buffer now triggers before Rugged and thus protects it.
- Fixed Virtue and ReduceDebuffsAction as a whole.