### PR TITLE
Guardian: fix Brace causing a softlock when the player doesn't have Mode Shift

### DIFF
--- a/src/main/java/guardian/actions/BraceAction.java
+++ b/src/main/java/guardian/actions/BraceAction.java
@@ -47,6 +47,7 @@ public class BraceAction extends AbstractGameAction {
                     if (AbstractDungeon.player.hasPower(ModeShiftPower.POWER_ID)) {
                         ((ModeShiftPower) AbstractDungeon.player.getPower(ModeShiftPower.POWER_ID)).onSpecificTrigger(braceValue);
                     }
+                    this.isDone = true;
                 }
             });
             addToTop(new ApplyPowerAction(AbstractDungeon.player, AbstractDungeon.player,


### PR DESCRIPTION
This bug was reported by someone playing Spire Biomes because there are various ways to get cards from other characters. Bracing when the player didn't have `ModeShiftPower` would softlock because `BraceAction` queued an action that never set `isDone`.

This PR implements a fix, which is very simple. I tested it locally.