### PR TITLE
Fix a crash that occurs when baby snecko fatally damages the silent mirror image boss.

### DIFF
--- a/src/main/java/charbosses/bosses/AbstractCharBoss.java
+++ b/src/main/java/charbosses/bosses/AbstractCharBoss.java
@@ -350,6 +350,10 @@ public abstract class AbstractCharBoss extends AbstractMonster {
     }
 
     public ArrayList<AbstractCard> getThisTurnCards() {
+        if (chosenArchetype == null) {
+            return new ArrayList<>();
+        }
+
         return chosenArchetype.getThisTurnCards();
     }
 


### PR DESCRIPTION
Judging by this stack trace the error is caused by the `die()` method nulling the `chosenArchetype`, but then an update is called on the char boss which tries to find which cards to add to the hand

This may just fix the symptom rather than the cause so feel free to close this or suggest a better way, but thought i'd have a go at fixing it myself. Thanks for the great mod, had a lot of fun with it.

```
java.lang.NullPointerException
	at charbosses.bosses.AbstractCharBoss.getThisTurnCards(AbstractCharBoss.java:353)
	at charbosses.bosses.AbstractCharBoss$1.update(AbstractCharBoss.java:372)
	at com.megacrit.cardcrawl.actions.GameActionManager.update(GameActionManager.java:179)
	at com.megacrit.cardcrawl.rooms.AbstractRoom.update(AbstractRoom.java:325)
	at com.megacrit.cardcrawl.dungeons.AbstractDungeon.update(AbstractDungeon.java:2532)
	at com.megacrit.cardcrawl.core.CardCrawlGame.update(CardCrawlGame.java:876)
	at com.megacrit.cardcrawl.core.CardCrawlGame.render(CardCrawlGame.java:423)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225)
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126)
	```